### PR TITLE
setup_environment_internal.py: Fix operator parsing in assignments

### DIFF
--- a/setup_environment_internal.py
+++ b/setup_environment_internal.py
@@ -309,9 +309,10 @@ def parse_assignment_expr(line):
                 if len(char) > 3:
                     raise Exception('Syntax error (operator): %s' % line)
             elif char == ' ':
-                if not op in ['=', '+=', '=+', '?=', '??=', ':=', '.=', '=.']:
-                    raise Exception('Invalid operator: %s' % op)
-                looking_for = 'val'
+                if op != '':
+                    if not op in ['=', '+=', '=+', '?=', '??=', ':=', '.=', '=.']:
+                        raise Exception('Invalid operator: %s' % op)
+                    looking_for = 'val'
             else:
                 raise Exception('Syntax error (operator): %s' % line)
         else:


### PR DESCRIPTION
Fix assignment parser for expressions with multiple spaces before the operator.

This fixes:

,----
| ...
|   File "sources/base/setup_environment_internal.py", line 384, in _parse_conf
|     expr = parse_assignment_expr(line)
|   File "sources/base/setup_environment_internal.py", line 313, in parse_assignment_expr
|     raise Exception('Invalid operator: %s' % op)
| Exception: Invalid operator: 
`----