### PR TITLE
Skip addpylib line

### DIFF
--- a/setup_environment_internal.py
+++ b/setup_environment_internal.py
@@ -385,6 +385,7 @@ class Conf(object):
         for line in lines:
             lstripped_line = line.lstrip()
             if (lstripped_line.startswith('require') or
+                lstripped_line.startswith('addpylib') or
                 lstripped_line.startswith('include')):
                 continue
             expr = parse_assignment_expr(line)


### PR DESCRIPTION
With current OE-core git master ( at commit 19eb1e388fbbe5bfb8462710c745f2bb5446b5b5 ), I get this error when running `. setup-environment build`:

```
Traceback (most recent call last):
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 627, in <module>
    load_modules()
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 193, in load_modules
    for module in find_modules():
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 134, in find_modules
    layers = find_layers()
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 523, in find_layers
    priority = get_layer_priority(layer_dir)
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 496, in get_layer_priority
    c.read_conf()
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 415, in read_conf
    self.conf_data = self._parse_conf(self._read_conf())
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 390, in _parse_conf
    expr = parse_assignment_expr(line)
  File "/home/test/build-setup/sources/base/setup_environment_internal.py", line 322, in parse_assignment_expr
    raise Exception('Syntax error (operator): %s' % line)
Exception: Syntax error (operator): addpylib ${LAYERDIR}/lib oeqa
```

This is related to the introduction of `addpylib` in OE-core, which was introduced in its commit 1f56155e91da2030ee0a5e93037c62e1349ba89f . This PR fixes the problem by skipping lines that start with `addpylib`.